### PR TITLE
Renamed ISeriesRelationalModel to IChartSeriesRelationalModel

### DIFF
--- a/src/Pure.Chart.RelationalModel.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Pure.Chart.RelationalModel.Abstractions/CompatibilitySuppressions.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Pure.Chart.RelationalModel.Abstractions.ISeriesRelationalModel</Target>
+    <Left>lib/net10.0/Pure.Chart.RelationalModel.Abstractions.dll</Left>
+    <Right>lib/net10.0/Pure.Chart.RelationalModel.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Pure.Chart.RelationalModel.Abstractions.ISeriesRelationalModel</Target>
+    <Left>lib/net7.0/Pure.Chart.RelationalModel.Abstractions.dll</Left>
+    <Right>lib/net7.0/Pure.Chart.RelationalModel.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Pure.Chart.RelationalModel.Abstractions.ISeriesRelationalModel</Target>
+    <Left>lib/net8.0/Pure.Chart.RelationalModel.Abstractions.dll</Left>
+    <Right>lib/net8.0/Pure.Chart.RelationalModel.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Pure.Chart.RelationalModel.Abstractions.ISeriesRelationalModel</Target>
+    <Left>lib/net9.0/Pure.Chart.RelationalModel.Abstractions.dll</Left>
+    <Right>lib/net9.0/Pure.Chart.RelationalModel.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Pure.Chart.RelationalModel.Abstractions/IChartSeriesRelationalModel.cs
+++ b/src/Pure.Chart.RelationalModel.Abstractions/IChartSeriesRelationalModel.cs
@@ -3,7 +3,7 @@ using Pure.Primitives.Abstractions.String;
 
 namespace Pure.Chart.RelationalModel.Abstractions;
 
-public interface ISeriesRelationalModel
+public interface IChartSeriesRelationalModel
 {
     public IGuid Id { get; }
 


### PR DESCRIPTION
Renamed ISeriesRelationalModel to IChartSeriesRelationalModel to avoid naming collisions with Pure.Diagram.RelationalModel.ISeriesRelationalModel